### PR TITLE
WIP: Decoder with an additonal endpoint with type as parameter

### DIFF
--- a/src/Decode.fs
+++ b/src/Decode.fs
@@ -1118,6 +1118,7 @@ module Decode =
         static member fromString(json: string, t: System.Type, ?isCamelCase : bool, ?extra: ExtraCoders) : Result<obj, string> =
             let decoder = Auto.generateDecoder(t = t, ?isCamelCase=isCamelCase, ?extra=extra)
             fromString decoder json
+
         static member unsafeFromString<'T>(json: string, ?isCamelCase : bool, ?extra: ExtraCoders): 'T =
             let decoder = Auto.generateDecoder(?isCamelCase=isCamelCase, ?extra=extra)
             match fromString decoder json with

--- a/src/Decode.fs
+++ b/src/Decode.fs
@@ -1095,6 +1095,14 @@ module Decode =
                 | Ok x -> Ok(x :?> 'T)
                 | Error er -> Error er
 
+        static member generateDecoder (t: System.Type, ?isCamelCase : bool, ?extra: ExtraCoders): Decoder<obj> =
+            let isCamelCase = defaultArg isCamelCase false
+            let decoderCrate = autoDecoder (makeExtra extra) isCamelCase false t
+            fun path token ->
+                match decoderCrate.Decode(path, token) with
+                | Ok x -> Ok(x)
+                | Error er -> Error er
+
         static member generateDecoder<'T> (?isCamelCase : bool, ?extra: ExtraCoders): Decoder<'T> =
             let isCamelCase = defaultArg isCamelCase false
             let decoderCrate = autoDecoder (makeExtra extra) isCamelCase false typeof<'T>
@@ -1107,6 +1115,9 @@ module Decode =
             let decoder = Auto.generateDecoder(?isCamelCase=isCamelCase, ?extra=extra)
             fromString decoder json
 
+        static member fromString(json: string, t: System.Type, ?isCamelCase : bool, ?extra: ExtraCoders) : Result<obj, string> =
+            let decoder = Auto.generateDecoder(t = t, ?isCamelCase=isCamelCase, ?extra=extra)
+            fromString decoder json
         static member unsafeFromString<'T>(json: string, ?isCamelCase : bool, ?extra: ExtraCoders): 'T =
             let decoder = Auto.generateDecoder(?isCamelCase=isCamelCase, ?extra=extra)
             match fromString decoder json with


### PR DESCRIPTION
Hi,

we are using thoth.json.net within a C# asp.net core project. To integrate the decorder you have to implement an IInputFormater. The problem there is, that the type is passed without generics. 

Therefor I need an endpint in the decoder to pass the type as function parameter.

This PR is only to show what I mean. I have no idea how to minimize the code duplication. Is someone able help out?