### PR TITLE
Include license information in nuget package

### DIFF
--- a/src/Thoth.Json.Net.fsproj
+++ b/src/Thoth.Json.Net.fsproj
@@ -2,7 +2,7 @@
     <PropertyGroup>
         <Description>Elm-inspired encoder and decoder for JSON targetting .Net and NetCore runtime</Description>
         <PackageProjectUrl>https://github.com/thoth-org/Thoth.Json.Net</PackageProjectUrl>
-        <Packagelicense>https://github.com/thoth-org/Thoth.Json.Net/blob/master/LICENSE.md</Packagelicense>
+        <PackageLicenseUrl>https://github.com/thoth-org/Thoth.Json.Net/blob/master/LICENSE.md</PackageLicenseUrl>
         <RepositoryUrl>https://github.com/thoth-org/Thoth.Json.Net</RepositoryUrl>
         <PackageTags>fsharp;json</PackageTags>
         <Authors>Maxime Mangel</Authors>


### PR DESCRIPTION
`<license type="expression">MIT</license>
<licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>`
will be added to the Thoth.Json.Net.nuspec