### PR TITLE
strings with invalid json characters are now handled correctly

### DIFF
--- a/src/Encode.fs
+++ b/src/Encode.fs
@@ -21,7 +21,9 @@ module Encode =
     ///**Exceptions**
     ///
     let string (value : string) : JsonValue =
-        JValue(value) :> JsonValue
+        match value with
+        |null -> JValue(value) :> JsonValue
+        |_ -> JsonConvert.ToString(value) |> JToken.Parse
 
     ///**Description**
     /// Encode a GUID


### PR DESCRIPTION
fix for #40 