### PR TITLE
[v6.0.0] Expose the helpers module so it can be used for custom decoders in user project

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -10,10 +10,10 @@ nuget Fable.Core ~> 3 framework: netstandard2.0
 
 group tests
     # Get the tests from Thoth.Json repo so both project are in sync
-    github thoth-org/Thoth.Json:master tests/Types.fs
-    github thoth-org/Thoth.Json:master tests/Decoders.fs
-    github thoth-org/Thoth.Json:master tests/Encoders.fs
-    github thoth-org/Thoth.Json:master tests/ExtraCoders.fs
+    github thoth-org/Thoth.Json:main tests/Types.fs
+    github thoth-org/Thoth.Json:main tests/Decoders.fs
+    github thoth-org/Thoth.Json:main tests/Encoders.fs
+    github thoth-org/Thoth.Json:main tests/ExtraCoders.fs
 
 group netcorebuild
     source https://www.nuget.org/api/v2

--- a/paket.lock
+++ b/paket.lock
@@ -1013,7 +1013,7 @@ GROUP tests
 
 GITHUB
   remote: thoth-org/Thoth.Json
-    tests/Decoders.fs (3b7f744fe3a00fd73007b6871674ad234da4a8e5)
-    tests/Encoders.fs (3b7f744fe3a00fd73007b6871674ad234da4a8e5)
-    tests/ExtraCoders.fs (3b7f744fe3a00fd73007b6871674ad234da4a8e5)
-    tests/Types.fs (3b7f744fe3a00fd73007b6871674ad234da4a8e5)
+    tests/Decoders.fs (748aa509503d65b80f50894ef9720718182eeef3)
+    tests/Encoders.fs (748aa509503d65b80f50894ef9720718182eeef3)
+    tests/ExtraCoders.fs (748aa509503d65b80f50894ef9720718182eeef3)
+    tests/Types.fs (748aa509503d65b80f50894ef9720718182eeef3)

--- a/src/Decode.fs
+++ b/src/Decode.fs
@@ -8,7 +8,7 @@ module Decode =
     open Newtonsoft.Json.Linq
     open System.IO
 
-    module private Helpers =
+    module Helpers =
         let anyToString (token: JsonValue) : string =
             if isNull token then "null"
             else


### PR DESCRIPTION
[https://github.com/thoth-org/Thoth.Json/commit/74a85519732719d13b68d034544c7a65aae91189](https://github.com/thoth-org/Thoth.Json/commit/74a85519732719d13b68d034544c7a65aae91189)

The `[<Inject>]` decorator (from this commit [https://github.com/thoth-org/Thoth.Json/commit/94838b6e60b7b3c457b4f5ca7e44110ba1ce8ec3](https://github.com/thoth-org/Thoth.Json/commit/94838b6e60b7b3c457b4f5ca7e44110ba1ce8ec3)) is a Fable/front-end specific thing? 